### PR TITLE
Adiciona CdbController e serviço para cálculo de CDB

### DIFF
--- a/cdbApp/cdbApp.Server/Controllers/CdbController.cs
+++ b/cdbApp/cdbApp.Server/Controllers/CdbController.cs
@@ -1,0 +1,33 @@
+﻿using cdbApp.Server.Interfaces;
+using cdbApp.Server.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace cdbApp.Server.Controllers;
+[Route("api/cdb")]
+[ApiController]
+public class CdbController : ControllerBase
+{
+    private readonly ICdbService _cdbService;
+
+    public CdbController(ICdbService cdbService)
+    {
+        _cdbService = cdbService;
+    }
+
+    [HttpGet]
+    public IActionResult Get([FromQuery] decimal initialValue, [FromQuery] int months)
+    {
+        if (initialValue <= 0 || months <= 0)
+        {
+            return StatusCode(StatusCodes.Status400BadRequest, "Initial value and months must be greater than 0");
+        }
+        var cdb = new Cdb(initialValue, months, _cdbService.GetTb(), _cdbService.GetCdi(), _cdbService.GetTax(months));
+        return Ok(new
+        {
+            initialValue = cdb.InitialValue,
+            finalValue = cdb.FinalValue,
+            finalValueWithTax = cdb.FinalValueWithTax
+        });
+    }
+}

--- a/cdbApp/cdbApp.Server/Interfaces/ICdbService.cs
+++ b/cdbApp/cdbApp.Server/Interfaces/ICdbService.cs
@@ -1,0 +1,8 @@
+﻿namespace cdbApp.Server.Interfaces;
+
+public interface ICdbService
+{
+    decimal GetTax(int months);
+    decimal GetTb();
+    decimal GetCdi();
+}

--- a/cdbApp/cdbApp.Server/Models/Cdb.cs
+++ b/cdbApp/cdbApp.Server/Models/Cdb.cs
@@ -1,0 +1,36 @@
+﻿using cdbApp.Server.Interfaces;
+using cdbApp.Server.Services;
+
+namespace cdbApp.Server.Models;
+
+public class Cdb
+{
+    public decimal InitialValue { get; private set; }
+    public int Months { get; private set; }
+    public decimal FinalValue { get; private set; }
+    public decimal FinalValueWithTax { get; private set; }
+
+    public Cdb(decimal initialValue, int months, decimal tb, decimal cdi, decimal tax)
+    {
+        InitialValue = initialValue;
+        Months = months;
+        FinalValue = GetFinalValue(tb, cdi);
+        FinalValueWithTax = GetFinalValueWithTax(FinalValue, tax);
+    }
+
+    private decimal GetFinalValue(decimal tb, decimal cdi)
+    {
+        decimal finalValue = InitialValue;
+
+        for (int i = 0; i < Months; i++)
+        {
+            finalValue *= (1 + (cdi * tb));
+        }
+        return finalValue;
+    }
+
+    private decimal GetFinalValueWithTax(decimal finalValue, decimal tax)
+    {
+        return finalValue - (finalValue * tax);
+    }
+}

--- a/cdbApp/cdbApp.Server/Program.cs
+++ b/cdbApp/cdbApp.Server/Program.cs
@@ -1,3 +1,7 @@
+using cdbApp.Server.Interfaces;
+using cdbApp.Server.Services;
+using Microsoft.OpenApi.Models;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
@@ -5,24 +9,31 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
+builder.Services.AddScoped<ICdbService, CdbService>();
+
+// Add Swagger services
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "cdbApp API", Version = "v1" });
+});
 
 var app = builder.Build();
 
-app.UseDefaultFiles();
-app.MapStaticAssets();
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
+    app.UseSwagger();
+    app.UseSwaggerUI();
     app.MapOpenApi();
 }
+app.UseDefaultFiles();
+app.MapStaticAssets();
 
 app.UseHttpsRedirection();
 
 app.UseAuthorization();
 
 app.MapControllers();
-
-app.MapFallbackToFile("/index.html");
 
 app.Run();

--- a/cdbApp/cdbApp.Server/Services/CdbService.cs
+++ b/cdbApp/cdbApp.Server/Services/CdbService.cs
@@ -1,0 +1,34 @@
+﻿using cdbApp.Server.Interfaces;
+
+namespace cdbApp.Server.Services;
+
+public class CdbService : ICdbService
+{
+    private readonly IConfiguration _configuration;
+
+    public CdbService(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    public decimal GetCdi()
+    {
+        return _configuration.GetValue<decimal>("CdbSettings:Cdi")/100;
+    }
+
+    public decimal GetTax(int months)
+    {
+        return months switch
+        {
+            <= 6 => 0.225M,
+            <= 12 => 0.2M,
+            <= 24 => 0.175M,
+            > 24 => 0.15M,
+        };
+    }
+
+    public decimal GetTb()
+    {
+        return _configuration.GetValue<decimal>("CdbSettings:Tb") / 100;
+    }
+}

--- a/cdbApp/cdbApp.Server/appsettings.json
+++ b/cdbApp/cdbApp.Server/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "CdbSettings": {
+    "Tb": 108.0,
+    "Cdi": 0.9
+  }
 }

--- a/cdbApp/cdbApp.Server/cdbApp.Server.csproj
+++ b/cdbApp/cdbApp.Server/cdbApp.Server.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.AspNetCore.SpaProxy">
       <Version>9.*-*</Version>
     </PackageReference>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Criação do `CdbController` com endpoint GET para cálculo de CDB.
- Adição da interface `ICdbService` com métodos para obter taxas.
- Criação da classe `Cdb` para lógica de cálculo de CDB.
- Implementação do `CdbService` para fornecer taxas de TB, CDI e imposto.
- Atualização do `Program.cs` para registrar `ICdbService` e configurar Swagger.
- Adição de configurações de TB e CDI no `appsettings.json`.